### PR TITLE
Corrigindo um erro que passou no PR

### DIFF
--- a/Minos/Minos.Site/Controllers/AdminController.cs
+++ b/Minos/Minos.Site/Controllers/AdminController.cs
@@ -368,12 +368,13 @@ namespace Minos.Site.Controllers
         [HttpPost]
         public IActionResult DesativarPergunta(int id)
         {
-            if (id <= 0)
+            if (id == 0)
             {
-                TempData["MensagemDanger"] = "Ocorreu um erro ao tentar desativar uma pergunta, por favor tente novamente";
+                TempData["Mensagem"] = "Ocorreu um erro ao tentar desativar uma pergunta, por favor tente novamente";
                 return RedirectToAction("CadastrarPergunta", "Admin");
             }
 
+            TempData["Sucesso"] = "Pergunta desativada com sucesso!";
             Pergunta pergunta = _perguntaRepository.ObterPerguntaPeloId(id);
             pergunta.Ativo = false;
             _perguntaRepository.Atualizar(pergunta);


### PR DESCRIPTION
Corrigindo um erro que tinha passado, o if de erro só verifica agora, se o if de pergunta for igual a 0 e enviamos uma msg de sucesso também para a desativação!